### PR TITLE
Added `coecms` channel specification for mule

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -25,7 +25,11 @@ requirements:
         - versioneer
     run:
         {% for dep in project.get('dependencies') %}
-        - {{ dep }}
+          {% if dep.startswith('mule') %}
+            - coecms::{{ dep }}
+          {% else %}
+            - {{ dep }}
+          {% endif %}
         {% endfor %}
 
 test:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -141,7 +141,7 @@ jobs:
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 #v2.0.8
         with:
           tag_name: ${{ github.ref_name }}
-          name: ${{needs.get-package-name.outputs.package-name}} ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
                 - 'setup.py'
                 - 'pyproject.toml'
                 - '.conda/env_build.yml'
-                - '.conda/meta.yml'
+                - '.conda/meta.yaml'
 
     verify-conda-build:
       name: Conda Build


### PR DESCRIPTION
The conda installation through:
```
conda install accessnri::umfile_utils
```
might fail because `mule` is not found unless either between the `coecms` or `accessnri` channels are "seen" by `conda`.

There are ways to specify channels, however, the other issue is that, for this release, the package is supposed to be a `noarch` one, as the [mule package in the `coecms` Anaconda channel](https://anaconda.org/coecms/mule) has a `noarch` version. The [mule package in the `accessnri` Anaconda channel](https://anaconda.org/accessnri/mule), however, doesn't have a `noarch` version, so it cannot be chosen as a dependency for `umfile_utils`.

For the moment, the best solution is to be specific about what channel to get the `mule` dependency from, within the package build metadata., to avoid problems when installing `umfile_utils`. 

In the future, it is suggested that multiple versions of `mule` are released within the `accessnri` Anaconda channel, also as `noarch` platform.

### Other minor unrelated changes
- [x] Changed release name from `umfile_utils <version>` to `<version>`
- [x] Fixed a bug with the meta.yaml not being picked when checking for changes