### PR TITLE
Fix validity time attributes

### DIFF
--- a/src/umfile_utils/change_dump_date.py
+++ b/src/umfile_utils/change_dump_date.py
@@ -138,13 +138,13 @@ def change_header_date_file(ff, new_year, new_month, new_day):
 
     if new_year is not None:
         ff.fixed_length_header.t1_year = new_year
-        ff.fixed_length_header.v1_year = new_year
+        ff.fixed_length_header.t2_year = new_year
     if new_month is not None:
         ff.fixed_length_header.t1_month = new_month
-        ff.fixed_length_header.v1_month = new_month
+        ff.fixed_length_header.t2_month = new_month
     if new_day is not None:
         ff.fixed_length_header.t1_day = new_day
-        ff.fixed_length_header.v1_day = new_day
+        ff.fixed_length_header.t2_day = new_day
 
 def change_header_date_all_fields(ff, new_year, new_month, new_day):
     """

--- a/tests/change_dump_date_test.py
+++ b/tests/change_dump_date_test.py
@@ -212,11 +212,11 @@ def create_mock_umfile():
 def mock_fixed_length_header():
     fixed_length_header = MagicMock()
     fixed_length_header.t1_year = 2000
-    fixed_length_header.v1_year = 2000
+    fixed_length_header.t2_year = 2000
     fixed_length_header.t1_month = 1
-    fixed_length_header.v1_month = 1
+    fixed_length_header.t2_month = 1
     fixed_length_header.t1_day = 1
-    fixed_length_header.v1_day = 1
+    fixed_length_header.t2_day = 1
     return fixed_length_header
 
 # Parameterized test for the function
@@ -241,11 +241,11 @@ def test_change_header_date_file(new_year, new_month, new_day, expected_year, ex
     change_header_date_file(ff, new_year, new_month, new_day)
 
     assert ff.fixed_length_header.t1_year == expected_year
-    assert ff.fixed_length_header.v1_year == expected_year
+    assert ff.fixed_length_header.t2_year == expected_year
     assert ff.fixed_length_header.t1_month == expected_month
-    assert ff.fixed_length_header.v1_month == expected_month
+    assert ff.fixed_length_header.t2_month == expected_month
     assert ff.fixed_length_header.t1_day == expected_day
-    assert ff.fixed_length_header.v1_day == expected_day
+    assert ff.fixed_length_header.t2_day == expected_day
 
 # Mocking the fields and the FieldsFile
 @pytest.fixture


### PR DESCRIPTION
Closes #28. This PR swaps the change_dump_date.py script to set the validity time using the `t2_(year/month/day)` attributes rather than `v1_(year/month/day), which don't exist in the mule `fixed_length_header` attribute.

Using the updated script to set the date to 18500101 in an ESM1.6 restart, we see that the initial data time and validity times are correctly set:

```
  (21) t1_year                          :      1850
  (22) t1_month                         :         1
  (23) t1_day                           :         1
  (24) t1_hour                          :         0
  (25) t1_minute                        :         0
  (26) t1_second                        :         0
  (27) t1_year_day_number               :         1
  (28) t2_year                          :      1850
  (29) t2_month                         :         1
  (30) t2_day                           :         1
  (31) t2_hour                          :         0
  (32) t2_minute                        :         0
  (33) t2_second                        :         0
  (34) t2_year_day_number               :         1
```